### PR TITLE
Scroll selected row into view, if needed

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -357,6 +357,7 @@ function IncSelected(offset) {
   state.selectedRow.dataset.selected = false;
   state.selectedRow = state.shownRows[idx];
   state.selectedRow.dataset.selected = true;
+  state.selectedRow.scrollIntoViewIfNeeded();
 }
 
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
Fix problem when selecting a row is outside the visible area using keyboard navigation