### PR TITLE
Add a button to close tab groups.

### DIFF
--- a/src/tabs.css
+++ b/src/tabs.css
@@ -2,11 +2,15 @@ body {
   font-family: Lucida Grande, sans-serif;
   background: #ccc;
 }
+.icon-area {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+}
 .icon {
   height: 32px;
   max-width: 32px;
   border-radius: 6px;
-  position: absolute;
 }
 .row {
   height: 26px;
@@ -108,8 +112,7 @@ body {
   transition: opacity 0s 0s, visibility 0s 0s;
   cursor: pointer;
 }
-.icon:hover ~ .group-close,
-.group-close:hover {
+.icon-area:hover .group-close {
   visibility: inherit;
   opacity: 1;
   transition: opacity .1s .1s, visibility 0s .1s;

--- a/src/tabs.css
+++ b/src/tabs.css
@@ -64,7 +64,7 @@ body {
 .row[data-selected=true] .title {
   background: #dff;
 }
-.close::before {
+.close::before, .group-close::before {
   content: "";
   width: 16px;
   height: 16px;
@@ -75,7 +75,7 @@ body {
   left: -8px;
   border-radius: 8px;
 }
-.close::after {
+.close::after, .group-close::after {
   content: "";
   width: 10px;
   height: 2px;
@@ -94,6 +94,22 @@ body {
   cursor: pointer;
 }
 .tab:hover .close {
+  visibility: inherit;
+  opacity: 1;
+  transition: opacity .1s .1s, visibility 0s .1s;
+}
+.group-close {
+  position: absolute;
+  left: 0;
+  top: 0;
+  display: block;
+  visibility: hidden;
+  opacity: 0;
+  transition: opacity 0s 0s, visibility 0s 0s;
+  cursor: pointer;
+}
+.icon:hover ~ .group-close,
+.group-close:hover {
   visibility: inherit;
   opacity: 1;
   transition: opacity .1s .1s, visibility 0s .1s;

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -217,9 +217,10 @@ function showTabs(currentId, tabs) {
       var t = create('DIV', 'grouptitle', g);
       t.textContent = group.title;
     }
-    var f = create('IMG', 'icon', g);
+    var iconArea = create('DIV', 'icon-area', g);
+    var f = create('IMG', 'icon', iconArea);
     f.src = group.favIconUrl || 'default_favicon.svg';
-    var gc = create('DIV', 'group-close', g);
+    var gc = create('DIV', 'group-close', iconArea);
     clickToCloseAll(gc, group.tabs.map(function(t) { return t.id; }));
 
     for (var j = 0; j < group.tabs.length; j++) {

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -176,6 +176,14 @@ function clickToClose(element, tid) {
   });
 }
 
+function clickToCloseAll(element, tids) {
+  element.addEventListener('click', function(e) {
+    e.stopPropagation();
+    e.preventDefault();
+    chrome.tabs.remove(tids);
+  });
+}
+
 function hoverToHilite(element, wid) {
   element.addEventListener('mouseenter', function() {
     hiliteTabs(wid);
@@ -211,6 +219,8 @@ function showTabs(currentId, tabs) {
     }
     var f = create('IMG', 'icon', g);
     f.src = group.favIconUrl || 'default_favicon.svg';
+    var gc = create('DIV', 'group-close', g);
+    clickToCloseAll(gc, group.tabs.map(function(t) { return t.id; }));
 
     for (var j = 0; j < group.tabs.length; j++) {
       var tab = group.tabs[j];

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -176,10 +176,17 @@ function clickToClose(element, tid) {
   });
 }
 
-function clickToCloseAll(element, tids) {
+function clickToCloseAll(element, group) {
   element.addEventListener('click', function(e) {
     e.stopPropagation();
     e.preventDefault();
+    var rows = group.querySelectorAll('.row');
+    var tids = [];
+    for (var i = 0; i < rows.length; i++) {
+      if (rows[i].dataset.show !== 'false') {
+        tids.push(rows[i].tid);
+      }
+    }
     chrome.tabs.remove(tids);
   });
 }
@@ -221,7 +228,7 @@ function showTabs(currentId, tabs) {
     var f = create('IMG', 'icon', iconArea);
     f.src = group.favIconUrl || 'default_favicon.svg';
     var gc = create('DIV', 'group-close', iconArea);
-    clickToCloseAll(gc, group.tabs.map(function(t) { return t.id; }));
+    clickToCloseAll(gc, g);
 
     for (var j = 0; j < group.tabs.length; j++) {
       var tab = group.tabs[j];


### PR DESCRIPTION
(Generated using Claude Code.)

Adds a close button at the top left of the favicon for tab groups. This feature was requested in #2 and by other users.

<img width="562" height="310" alt="Screenshot 2026-02-25 at 7 39 57 PM" src="https://github.com/user-attachments/assets/8d5cfc88-5f9e-495e-908e-321fa9ebf26d" />

Also confirmed that it works when the tab groups have names:

<img width="562" height="310" alt="Screenshot 2026-02-25 at 7 41 24 PM" src="https://github.com/user-attachments/assets/a187a9b1-597b-490f-8d8f-e6fc3937443a" />

Also tested with filtering/searching to ensure it only closes the visible tabs in a group when a search is active and matches some but not all of the group's tabs.
